### PR TITLE
Make rate limit test more lenient

### DIFF
--- a/FortnoxSDK.Tests/RateLimiterTests.cs
+++ b/FortnoxSDK.Tests/RateLimiterTests.cs
@@ -39,7 +39,7 @@ public class RateLimiterTests
          * 200 requests should be executed in ~50 seconds.
          */
         Assert.AreEqual(200, counter);
-        Assert.IsTrue(watch.Elapsed.TotalSeconds is > 49 and < 51);
+        Assert.IsTrue(watch.Elapsed.TotalSeconds is > 48 and < 52);
     }
 
     [Ignore("Can make other test fail due to exhausting rate limiter")]

--- a/FortnoxSDK.Tests/RateLimiterTests.cs
+++ b/FortnoxSDK.Tests/RateLimiterTests.cs
@@ -37,9 +37,10 @@ public class RateLimiterTests
         /*
          * Given the rate limiter of 4 requests per second,
          * 200 requests should be executed in ~50 seconds.
+         * Note: time per request might be longer than 250ms, hence the longer maximum allowed elapsed time
          */
         Assert.AreEqual(200, counter);
-        Assert.IsTrue(watch.Elapsed.TotalSeconds is > 48 and < 52);
+        Assert.IsTrue(watch.Elapsed.TotalSeconds is > 49 and < 65);
     }
 
     [Ignore("Can make other test fail due to exhausting rate limiter")]

--- a/FortnoxSDK/Connectors/Base/BaseClient.cs
+++ b/FortnoxSDK/Connectors/Base/BaseClient.cs
@@ -26,7 +26,7 @@ internal abstract class BaseClient
             Authorization?.ApplyTo(request);
 
             if (UseRateLimiter)
-                await RateLimiter.Trottle(Authorization?.AccessToken).ConfigureAwait(false);
+                await RateLimiter.Throttle(Authorization?.AccessToken).ConfigureAwait(false);
 
             using var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
 

--- a/FortnoxSDK/Connectors/Base/RateLimiter.cs
+++ b/FortnoxSDK/Connectors/Base/RateLimiter.cs
@@ -10,13 +10,13 @@ namespace Fortnox.SDK.Connectors.Base;
 /// Rate limit - 4 requests per 1 seconds per token
 /// </summary>
 internal class RateLimiter
-{    
+{
     private const int MaxCount = 4;
     private static readonly TimeSpan Period = TimeSpan.FromSeconds(1);
-    
+
     private static readonly Dictionary<string, TimeLimiter> RateLimiters = new();
 
-    public async Task Trottle(string token)
+    public async Task Throttle(string token)
     {
         if (token == null)
             return;


### PR DESCRIPTION
The rate limit test seems to fail more often than not when ran in Actions, but it never seems to be an issue when running the tests locally. 
Instead of only allowing 50s for the elapsed time of the test, 49-51s should make it fail less often