### PR TITLE
Update test names

### DIFF
--- a/FortnoxSDK.Tests/ConnectorTests/AbsenceTransactionTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/AbsenceTransactionTests.cs
@@ -75,7 +75,7 @@ public class AbsenceTransactionTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_AbsenceTransaction_Find()
     {
         #region Arrange
         var tmpEmployee = await TestUtils.GetBasicTestEmployee();

--- a/FortnoxSDK.Tests/ConnectorTests/AccountChartTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/AccountChartTests.cs
@@ -17,7 +17,7 @@ public class AccountChartTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_AccountChart_Find()
     {
         var connector = FortnoxClient.AccountChartConnector;
 

--- a/FortnoxSDK.Tests/ConnectorTests/AccountTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/AccountTests.cs
@@ -123,7 +123,7 @@ public class AccountTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Account_Find()
     {
         #region Arrange
         //Add code to create required resources

--- a/FortnoxSDK.Tests/ConnectorTests/ArticleTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/ArticleTests.cs
@@ -72,7 +72,7 @@ public class ArticleTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Article_Find()
     {
         #region Arrange
         //Add code to create required resources

--- a/FortnoxSDK.Tests/ConnectorTests/AssetTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/AssetTests.cs
@@ -79,7 +79,7 @@ public class AssetTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Asset_Find()
     {
         #region Arrange
         var tmpCostCenter = await FortnoxClient.CostCenterConnector.CreateAsync(new CostCenter() { Code = "TMPCC", Description = "TempCostCenter" });

--- a/FortnoxSDK.Tests/ConnectorTests/AttendanceTransactionsTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/AttendanceTransactionsTests.cs
@@ -75,7 +75,7 @@ public class AttendanceTransactionsTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_AttendanceTransactions_Find()
     {
         #region Arrange
         var tmpEmployee = await TestUtils.GetBasicTestEmployee();

--- a/FortnoxSDK.Tests/ConnectorTests/CostCenterTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/CostCenterTests.cs
@@ -67,7 +67,7 @@ public class CostCenterTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_CostCenter_Find()
     {
         #region Arrange
         //Add code to create required resources

--- a/FortnoxSDK.Tests/ConnectorTests/CustomerReferenceTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/CustomerReferenceTests.cs
@@ -70,7 +70,7 @@ public class CustomerReferenceTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_CustomerReference_Find()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TestCustomer" });
@@ -115,7 +115,7 @@ public class CustomerReferenceTests
 
     // Requires at least 101 customer references to exist in data source
     [TestMethod]
-    public async Task Test_Find_Unlimited()
+    public async Task Test_CustomerReference_Find_Unlimited()
     {
         var connector = FortnoxClient.CustomerReferenceConnector;
 

--- a/FortnoxSDK.Tests/ConnectorTests/CustomerTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/CustomerTests.cs
@@ -72,7 +72,7 @@ public class CustomerTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Customer_Find()
     {
         #region Arrange
         //Add code to create required resources

--- a/FortnoxSDK.Tests/ConnectorTests/InvoiceTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/InvoiceTests.cs
@@ -81,7 +81,7 @@ public class InvoiceTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Invoice_Find()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });
@@ -141,7 +141,7 @@ public class InvoiceTests
     }
 
     [TestMethod]
-    public async Task Test_DueDate()
+    public async Task Test_Invoice_DueDate()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });
@@ -187,7 +187,7 @@ public class InvoiceTests
 
     [TestMethod]
     [Ignore("Fails with error 'Kan inte skicka dokument om inte företaget är registrerat'")]
-    public async Task Test_EPrint()
+    public async Task Test_Invoice_EPrint()
     {
         #region Arrange
         var cc = FortnoxClient.CustomerConnector;
@@ -229,7 +229,7 @@ public class InvoiceTests
 
     [Ignore("Fails with 'Bankuppgifter saknas'")]
     [TestMethod]
-    public async Task Test_Print()
+    public async Task Test_Invoice_Print()
     {
         #region Arrange
         var cc = FortnoxClient.CustomerConnector;
@@ -271,7 +271,7 @@ public class InvoiceTests
 
     [Ignore("Fails with 'Bankuppgifter saknas'")]
     [TestMethod]
-    public async Task Test_Email()
+    public async Task Test_Invoice_Email()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis", Email = "richard.randak@softwerk.se" });
@@ -310,7 +310,7 @@ public class InvoiceTests
     }
 
     [TestMethod]
-    public async Task Test_Search()
+    public async Task Test_Invoice_Search()
     {
         var connector = FortnoxClient.InvoiceConnector;
         var searchSettings = new InvoiceSearch();

--- a/FortnoxSDK.Tests/ConnectorTests/LabelTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/LabelTests.cs
@@ -59,7 +59,7 @@ public class LabelTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Label_Find()
     {
         var connector = FortnoxClient.LabelConnector;
 

--- a/FortnoxSDK.Tests/ConnectorTests/ModeOfPaymentTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/ModeOfPaymentTests.cs
@@ -68,7 +68,7 @@ public class ModeOfPaymentTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_ModeOfPayment_Find()
     {
         #region Arrange
         var tmpAccount = await FortnoxClient.AccountConnector.CreateAsync(new Account() { Description = "TestAccount", Number = TestUtils.GetUnusedAccountNumber() });

--- a/FortnoxSDK.Tests/ConnectorTests/OfferTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/OfferTests.cs
@@ -76,7 +76,7 @@ public class OfferTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Offer_Find()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });
@@ -133,7 +133,7 @@ public class OfferTests
     }
 
     [TestMethod]
-    public async Task Test_Print()
+    public async Task Test_Offer_Print()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });
@@ -168,7 +168,7 @@ public class OfferTests
     }
 
     [TestMethod]
-    public async Task Test_Email()
+    public async Task Test_Offer_Email()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis", Email = "richard.randak@softwerk.se" });

--- a/FortnoxSDK.Tests/ConnectorTests/OrderTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/OrderTests.cs
@@ -73,7 +73,7 @@ public class OrderTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Order_Find()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });
@@ -130,7 +130,7 @@ public class OrderTests
     }
 
     [TestMethod]
-    public async Task Test_Print()
+    public async Task Test_Order_Print()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });
@@ -165,7 +165,7 @@ public class OrderTests
     }
 
     [TestMethod]
-    public async Task Test_Email()
+    public async Task Test_Order_Email()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis", Email = "richard.randak@softwerk.se" });

--- a/FortnoxSDK.Tests/ConnectorTests/PredefinedAccountsTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/PredefinedAccountsTests.cs
@@ -35,7 +35,7 @@ public class PredefinedAccountsTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_PredefinedAccounts_Find()
     {
         var connector = FortnoxClient.PredefinedAccountsConnector;
 

--- a/FortnoxSDK.Tests/ConnectorTests/PredefinedVoucherSeriesTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/PredefinedVoucherSeriesTests.cs
@@ -31,7 +31,7 @@ public class PredefinedVoucherSeriesTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_PredefinedVoucherSeries_Find()
     {
         var connector = FortnoxClient.PredefinedVoucherSeriesConnector;
 

--- a/FortnoxSDK.Tests/ConnectorTests/PriceListTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/PriceListTests.cs
@@ -60,7 +60,7 @@ public class PriceListTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_PriceList_Find()
     {
         var connector = FortnoxClient.PriceListConnector;
 

--- a/FortnoxSDK.Tests/ConnectorTests/PriceTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/PriceTests.cs
@@ -69,7 +69,7 @@ public class PriceTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Price_Find()
     {
         #region Arrange
         var tmpArticleA = await FortnoxClient.ArticleConnector.CreateAsync(new Article() { Description = "TmpArticleA", PurchasePrice = 10 });
@@ -140,7 +140,7 @@ public class PriceTests
     }
 
     [TestMethod]
-    public async Task Test_Find_Args_Specified()
+    public async Task Test_Price_Find_Args_Specified()
     {
         #region Arrange
         var tmpArticle = await FortnoxClient.ArticleConnector.CreateAsync(new Article() { Description = "TmpArticle", PurchasePrice = 10 });

--- a/FortnoxSDK.Tests/ConnectorTests/PrintTemplateTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/PrintTemplateTests.cs
@@ -18,7 +18,7 @@ public class PrintTemplateTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_PrintTemplate_Find()
     {
         var connector = FortnoxClient.PrintTemplateConnector;
 
@@ -31,7 +31,7 @@ public class PrintTemplateTests
     }
 
     [TestMethod]
-    public async Task Test_Find_Filter()
+    public async Task Test_PrintTemplate_Find_Filter()
     {
         var connector = FortnoxClient.PrintTemplateConnector;
         var searchSettings = new PrintTemplateSearch();

--- a/FortnoxSDK.Tests/ConnectorTests/ProjectTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/ProjectTests.cs
@@ -72,7 +72,7 @@ public class ProjectTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Project_Find()
     {
         #region Arrange
         //Add code to create required resources
@@ -125,7 +125,7 @@ public class ProjectTests
     }
 
     [TestMethod]
-    public async Task Test_Find_By_Description()
+    public async Task Test_Project_Find_By_Description()
     {
         #region Arrange
         //Add code to create required resources

--- a/FortnoxSDK.Tests/ConnectorTests/ScheduleTimesTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/ScheduleTimesTests.cs
@@ -11,6 +11,7 @@ public class ScheduleTimesTests
 {
     public FortnoxClient FortnoxClient = TestUtils.DefaultFortnoxClient;
 
+    [Ignore("Unable to update Hours using test credentials, re-enable after switching from StaticTokenAuth to a service account with StandardAuth")]
     [TestMethod]
     public async Task Test_ScheduleTimes_CRUD()
     {

--- a/FortnoxSDK.Tests/ConnectorTests/SupplierInvoiceTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/SupplierInvoiceTests.cs
@@ -80,7 +80,7 @@ public class SupplierInvoiceTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_SupplierInvoice_Find()
     {
         #region Arrange
         var tmpSupplier = await FortnoxClient.SupplierConnector.CreateAsync(new Supplier() { Name = "TmpSupplier" });
@@ -141,7 +141,7 @@ public class SupplierInvoiceTests
     }
 
     [TestMethod]
-    public async Task Test_Book()
+    public async Task Test_SupplierInvoice_Book()
     {
         #region Arrange
         var tmpSupplier = await FortnoxClient.SupplierConnector.CreateAsync(new Supplier() { Name = "TmpSupplier" });

--- a/FortnoxSDK.Tests/ConnectorTests/SupplierTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/SupplierTests.cs
@@ -78,7 +78,7 @@ public class SupplierTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Supplier_Find()
     {
         #region Arrange
         //Add code to create required resources
@@ -138,7 +138,7 @@ public class SupplierTests
     }
 
     [TestMethod]
-    public async Task VatType_Supported()
+    public async Task Test_Supplier_VatType_Supported()
     {
         var vatTypes = Enum.GetValues(typeof(SupplierVATType)).Cast<SupplierVATType>().ToList();
 

--- a/FortnoxSDK.Tests/ConnectorTests/TaxReductionTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/TaxReductionTests.cs
@@ -99,7 +99,7 @@ public class TaxReductionTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_TaxReduction_Find()
     {
         #region Arrange
         var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });

--- a/FortnoxSDK.Tests/ConnectorTests/TermsOfDeliveryTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/TermsOfDeliveryTests.cs
@@ -65,7 +65,7 @@ public class TermsOfDeliveryTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_TermsOfDelivery_Find()
     {
         var connector = FortnoxClient.TermsOfDeliveryConnector;
 
@@ -79,7 +79,7 @@ public class TermsOfDeliveryTests
         {
             await connector.DeleteAsync(entry.Code);
         }
-         
+
         var newTermsOfDelivery = new TermsOfDelivery()
         {
             Description = "TestDeliveryTerms"
@@ -102,7 +102,7 @@ public class TermsOfDeliveryTests
 
         //Apply Limit
         //Terms of deleivery not working limit and not returning MetaInformation from fortnox response, so limit will not work as expected
-        searchSettings.Limit = 5; 
+        searchSettings.Limit = 5;
         var limitedCollection = await connector.FindAsync(searchSettings);
 
         Assert.AreEqual(5, limitedCollection.Entities.Count);

--- a/FortnoxSDK.Tests/ConnectorTests/TermsOfPaymentTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/TermsOfPaymentTests.cs
@@ -65,7 +65,7 @@ public class TermsOfPaymentTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_TermsOfPayment_Find()
     {
         var connector = FortnoxClient.TermsOfPaymentConnector;
 
@@ -91,13 +91,13 @@ public class TermsOfPaymentTests
                 foreach (var entry in fullCollectionExists.Entities)
                 {
                     await connector.DeleteAsync(entry.Code);
-                } 
+                }
 
                 searchSettingsExits.Page = fullCollectionExists.CurrentPage + 1;
                 fullCollectionExists = await connector.FindAsync(searchSettingsExits);
             }
         }
-       
+
 
         var newTermsOfPayment = new TermsOfPayment()
         {

--- a/FortnoxSDK.Tests/ConnectorTests/UnitTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/UnitTests.cs
@@ -67,7 +67,7 @@ public class UnitTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_Unit_Find()
     {
         var connector = FortnoxClient.UnitConnector;
 

--- a/FortnoxSDK.Tests/ConnectorTests/VoucherFileConnectionTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/VoucherFileConnectionTests.cs
@@ -77,7 +77,7 @@ public class VoucherFileConnectionTests
     }
 
     [TestMethod]
-    public async Task Create_NonDefaultYear()
+    public async Task Create_VoucherFileConnection_NonDefaultYear()
     {
         #region Arrange
 

--- a/FortnoxSDK.Tests/ConnectorTests/WayOfDeliveryTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/WayOfDeliveryTests.cs
@@ -67,7 +67,7 @@ public class WayOfDeliveryTests
     }
 
     [TestMethod]
-    public async Task Test_Find()
+    public async Task Test_WayOfDelivery_Find()
     {
         var connector = FortnoxClient.WayOfDeliveryConnector;
 


### PR DESCRIPTION
While some test classes have fully unique test names, there are still many instances of generic "Test_Find()" in the project. 
This PR aims to update up the consistency and make it easier to troubleshoot failing tests  