### PR TITLE
Update rate limit

### DIFF
--- a/FortnoxSDK.Tests/RateLimiterTests.cs
+++ b/FortnoxSDK.Tests/RateLimiterTests.cs
@@ -35,12 +35,15 @@ public class RateLimiterTests
         watch.Stop();
 
         /*
-         * Given the rate limiter of 4 requests per second,
-         * 200 requests should be executed in ~50 seconds.
-         * Note: time per request might be longer than 250ms, hence the longer maximum allowed elapsed time
+         * Given the rate limiter of 4.8 requests per second (24/5),
+         * 200 requests should be executed in ~41 seconds.
+         * 
+         * If we can increase the rate limiter to the advertised 25/5 (5 per second), 
+         * 200 requests should be executed in ~40 seconds.
          */
+
         Assert.AreEqual(200, counter);
-        Assert.IsTrue(watch.Elapsed.TotalSeconds is > 49 and < 65);
+        Assert.IsTrue(watch.Elapsed.TotalSeconds is > 40);
     }
 
     [Ignore("Can make other test fail due to exhausting rate limiter")]

--- a/FortnoxSDK/Connectors/Base/RateLimiter.cs
+++ b/FortnoxSDK/Connectors/Base/RateLimiter.cs
@@ -7,12 +7,12 @@ using RateLimiter;
 namespace Fortnox.SDK.Connectors.Base;
 
 /// <summary>
-/// Rate limit - 4 requests per 1 seconds per token
+/// Rate limit - 25 requests per 5 seconds per token 
 /// </summary>
 internal class RateLimiter
 {
-    private const int MaxCount = 4;
-    private static readonly TimeSpan Period = TimeSpan.FromSeconds(1);
+    private const int MaxCount = 24; // Rate limit is 25 requests over 5 second sliding window, but using the max allowed still seems to trigger the limit. 24 req per 5 sec seems to work consistently.
+    private static readonly TimeSpan Period = TimeSpan.FromSeconds(5);
 
     private static readonly Dictionary<string, TimeLimiter> RateLimiters = new();
 


### PR DESCRIPTION
The rate limit of the API has been increased from 4/s to 5/s a couple of years back.

In PR #258 this limit was increased in the SDK, but was shortly reverted due to concerns of inconsistencies between legacy tokens and the new OAuth2 workflow. 
After some tests with both authentication methods, it seems they are both using the same sliding window now.

Closes #322
