### PR TITLE
Make all requests use HTTP/2 by default

### DIFF
--- a/FortnoxSDK/Connectors/Base/BaseClient.cs
+++ b/FortnoxSDK/Connectors/Base/BaseClient.cs
@@ -11,6 +11,7 @@ internal abstract class BaseClient
     public HttpClient HttpClient { get; set; }
 
     public bool UseRateLimiter { get; set; } = true;
+    public bool UseHttp2 { get; set; } = true;
     public FortnoxAuthorization Authorization { get; set; }
 
     protected BaseClient()
@@ -27,6 +28,9 @@ internal abstract class BaseClient
 
             if (UseRateLimiter)
                 await RateLimiter.Throttle(Authorization?.AccessToken).ConfigureAwait(false);
+
+            if (UseHttp2)
+                request.Version = new System.Version(2, 0);
 
             using var response = await HttpClient.SendAsync(request).ConfigureAwait(false);
 

--- a/FortnoxSDK/FortnoxClient.cs
+++ b/FortnoxSDK/FortnoxClient.cs
@@ -34,6 +34,13 @@ public class FortnoxClient
     public bool UseRateLimiter { get; set; } = true;
 
     /// <summary>
+    /// HTTP/2 will be used for each request.
+    /// If set to false, HTTP/1.1 will be used.
+    /// </summary>
+    /// <value>Defaults to <c>true</c>.</value>
+    public bool UseHttp2 { get; set; } = true;
+
+    /// <summary>
     /// Some features require warehouse module to be enabled.
     /// If not set, some properties in the model may be ignored.
     /// </summary>
@@ -43,17 +50,19 @@ public class FortnoxClient
     {
     }
 
-    public FortnoxClient(FortnoxAuthorization authorization, bool useRateLimiter = true)
+    public FortnoxClient(FortnoxAuthorization authorization, bool useRateLimiter = true, bool useHttp2 = true)
     {
         Authorization = authorization;
         UseRateLimiter = useRateLimiter;
+        UseHttp2 = useHttp2;
     }
 
-    public FortnoxClient(FortnoxAuthorization authorization, HttpClient httpClient, bool useRateLimiter = true)
+    public FortnoxClient(FortnoxAuthorization authorization, HttpClient httpClient, bool useRateLimiter = true, bool useHttp2 = true)
     {
         Authorization = authorization;
         HttpClient = httpClient;
         UseRateLimiter = useRateLimiter;
+        UseHttp2 = useHttp2;
     }
 
     private TConnector Get<TConnector>() where TConnector : BaseConnector, new()
@@ -63,6 +72,7 @@ public class FortnoxClient
             Authorization = Authorization,
             HttpClient = HttpClient,
             UseRateLimiter = UseRateLimiter,
+            UseHttp2 = UseHttp2,
             WarehouseEnabled = WarehouseEnabled
         };
     }

--- a/FortnoxSDK/Interfaces/IConnector.cs
+++ b/FortnoxSDK/Interfaces/IConnector.cs
@@ -12,6 +12,7 @@ public interface IConnector
     // Config
     HttpClient HttpClient { get; }
     bool UseRateLimiter { get; }
+    bool UseHttp2 { get; }
 }
 
 public interface IEntityConnector : IConnector


### PR DESCRIPTION
All requests will use HTTP 2.0 (HTTP/2) by default with this PR.

To turn this behaviour off and revert to using HTTP 1.1, do the following when creating your `FortnoxClient`:
`var client = new FortnoxClient(auth, true, false)`.

The constructors now look like this: 
- new FortnoxClient(authorization, useRateLimiter, useHttp2)
- new FortnoxClient(authorization, httpClient, useRateLimiter, useHttp2)
